### PR TITLE
feat: get an event from DB using uuid

### DIFF
--- a/src/main/java/com/sky/events_api_project/controller/EventsController.java
+++ b/src/main/java/com/sky/events_api_project/controller/EventsController.java
@@ -20,4 +20,9 @@ public class EventsController {
     public ResponseEntity<Event> updateEvent(@RequestParam String uuid){
         return eventsService.updateEvent(uuid);
     }
+
+    @GetMapping("/get")
+    public ResponseEntity<Event> getEventByUUID(@RequestParam String uuid){
+        return eventsService.getEventByUUID(uuid);
+    }
 }

--- a/src/main/java/com/sky/events_api_project/service/EventsService.java
+++ b/src/main/java/com/sky/events_api_project/service/EventsService.java
@@ -34,4 +34,9 @@ public class EventsService {
         }
         else return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
+
+    public ResponseEntity<Event> getEventByUUID(String uuid){
+        Optional<Event> event = eventsRepository.findById(uuid);
+        return event.map(value -> new ResponseEntity<>(value, HttpStatus.OK)).orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
 }

--- a/src/test/java/com/sky/events_api_project/controller/EventsControllerUnitTest.java
+++ b/src/test/java/com/sky/events_api_project/controller/EventsControllerUnitTest.java
@@ -38,4 +38,12 @@ public class EventsControllerUnitTest {
         assertThat(responseEntity.getBody()).isEqualTo(expectedEvent);
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
+    @Test
+    public void givenGetRequestWithUUID_whenProcessed_thenReturnEvent(){
+        Event expectedEvent = new Event();
+        when(eventsService.getEventByUUID(any())).thenReturn(new ResponseEntity<>(expectedEvent,HttpStatus.OK));
+        ResponseEntity<Event> responseEntity = eventsController.getEventByUUID(any());
+        assertThat(responseEntity.getBody()).isEqualTo(expectedEvent);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
 }

--- a/src/test/java/com/sky/events_api_project/service/EventsServiceUnitTest.java
+++ b/src/test/java/com/sky/events_api_project/service/EventsServiceUnitTest.java
@@ -68,4 +68,19 @@ public class EventsServiceUnitTest {
         assertThat(responseEntity.getBody()).isEqualTo(null);
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
     }
+    @Test
+    public void givenKnownUUID_whenFindInDB_thenReturnEvent(){
+        Event expectedEvent = new Event();
+        when(eventsRepository.findById(any())).thenReturn(Optional.of(expectedEvent));
+        ResponseEntity<Event> responseEntity = eventsService.getEventByUUID(any());
+        assertThat(responseEntity.getBody()).isEqualTo(expectedEvent);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+    @Test
+    public void givenUnknownUUID_whenFindInDB_thenReturnError(){
+        when(eventsRepository.findById(any())).thenReturn(Optional.empty());
+        ResponseEntity<Event> responseEntity = eventsService.getEventByUUID(any());
+        assertThat(responseEntity.getBody()).isEqualTo(null);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
 }


### PR DESCRIPTION
Acceptance criteria met:

- retrieve an event from the DB using its uuid
- successful Response returns 200 response code with event in response body
- when record not found in DB, then return response code 404